### PR TITLE
Create get route for counties, all option for interests

### DIFF
--- a/routes/api/counties.js
+++ b/routes/api/counties.js
@@ -7,13 +7,15 @@ router.patch('/search', async (req, res) => {
   const params = {state: req.body.state, county: req.body.county};
 
   const updatedInterests = {};
-  if (req.body.interests){
-    console.log(req.body.interests);
+  if (req.body.interests && (req.body.interests !== "all")){
     const interests = req.body.interests.split('%20');
-    console.log(interests)
     for (i = 0; i < interests.length; i++) {
       updatedInterests[interests[i]] = 1
     }
+  }else if(req.body.interests === "all"){
+    updatedInterests['education'] = 1
+    updatedInterests['justice'] = 1
+    updatedInterests['legislation'] = 1
   }
 
   const county = await County.findOneAndUpdate(params,
@@ -22,6 +24,14 @@ router.patch('/search', async (req, res) => {
     },
     {new:true},
   ).then((updatedCounty) => res.json(updatedCounty))
-})
+});
+
+router.get('/county', (req, res) => {
+  County.find({county: req.body.county, state:req.body.state})
+    .then(county => res.json(county))
+    .catch(err =>
+      res.status(404).json({ nocountyfound: `${req.body.county} not found in ${req.body.state}`})
+    );
+});
 
 module.exports = router;


### PR DESCRIPTION
Can now retrieve counties by giving name and state, can now use "all" as a parameter when the patch method "/search" is called and increment all interests.